### PR TITLE
Update TAP dependency to 0.0.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,17 @@
         "repositoryURL": "https://github.com/SwiftDocOrg/TAP.git",
         "state": {
           "branch": null,
-          "revision": "9c8da52495ebaf3275c5fa03cb423d1272351ec2",
-          "version": null
+          "revision": "768b937be16d585d61d1496cc2c99518429650ff",
+          "version": "0.0.2"
+        }
+      },
+      {
+        "package": "Yams",
+        "repositoryURL": "https://github.com/jpsim/Yams.git",
+        "state": {
+          "branch": null,
+          "revision": "c947a306d2e80ecb2c0859047b35c73b8e1ca27f",
+          "version": "2.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,8 +14,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/apple/swift-syntax.git", .revision("0.50200.0")),
-        .package(url: "https://github.com/SwiftDocOrg/TAP.git", .revision("9c8da52495ebaf3275c5fa03cb423d1272351ec2")),
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "0.0.4")),
+        .package(url: "https://github.com/SwiftDocOrg/TAP.git", .upToNextMinor(from: "0.0.2")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
This release uses Yams as a transient dependency, which previously [had issues](https://github.com/jpsim/Yams/issues/244), but now seems to work locally for whatever reason.